### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Script to export Linky consumption in JSON format !
 
 ## What is this?
-This is a script based on Linkindle, created by Outadoc (https://github.com/outadoc/linkindle), allowing to get consumption from Enedis' website (https://espace-client-connexion.erdf.fr/auth/UI/Login?realm=particuliers), through API.
-This generates JSON files ready to be plotted with Highcharts for example.
+This is a script based on Linkindle, created by Outadoc (https://github.com/outadoc/linkindle), allowing to get power consumption from Enedis' website (https://espace-client-connexion.erdf.fr/auth/UI/Login?realm=particuliers), through the API.
+
+It generates JSON files ready to be plotted with Highcharts for example.
 
 ## Output
 The script will generate 4 JSON files for :
@@ -15,17 +16,15 @@ The script will generate 4 JSON files for :
 ## Requirements
 This script requires the use of Python 3 with the following dependencies:
 
-- dateutil
-- requests
-- json
+- dateutil (`pip3 install python-dateutil`)
+- requests (`pip3 install requests`)
 
 ## Usage
-In "gen_json.sh" script, set up environment variables containing your Enedis email and password.
-Don't forget to uncomment the following lines:
+In the `gen_json.sh` script, set up environment variables containing your Enedis credentials by uncommenting and editing the following lines:
 
 	export LINKY_USERNAME="prenom.nom@mail.com"
 	export LINKY_PASSWORD="password"
 
+Then, just run `./gen_json.sh` to generate the JSON files. A log will be saved in `linky.log`.
 
-Then, just run "gen_json.sh" script to generate the JSON files.
 Fell free to add a cron to get ENEDIS data periodically.


### PR DESCRIPTION
- Removed `json` from dependencies as it's already included in python
- Added pip commands as the module name can be different there (dateutil VS python-dateutil)
- Used ` instead of ' to display file names in monospace
- Added info about  `linky.log`
- Changed the phrasing a little bit